### PR TITLE
Update to fix static => const rename

### DIFF
--- a/arch/arm/cpu/mmu.rs
+++ b/arch/arm/cpu/mmu.rs
@@ -7,17 +7,17 @@ use kernel::mm::physical::Phys;
 
 pub type Frame = [u8, ..PAGE_SIZE];
 
-static PAGE_SIZE: uint = 0x1000;
-static PAGE_SIZE_LOG2: uint = 12;
+const PAGE_SIZE: uint = 0x1000;
+const PAGE_SIZE_LOG2: uint = 12;
 
 // kinda clever
 bitflags!(flags Flags: u32 {
-    static SECTION = 0b10010,
+    const SECTION = 0b10010,
 
-    static BUFFER = 1 << 2,
-    static CACHE  = 1 << 3,
-    static RW     = 1 << 10,
-    static CLIENT_ACCESS = 1 << 11
+    const BUFFER = 1 << 2,
+    const CACHE  = 1 << 3,
+    const RW     = 1 << 10,
+    const CLIENT_ACCESS = 1 << 11
 })
 
 #[repr(packed)]
@@ -58,11 +58,11 @@ define_reg!(CR, CRFlags: uint {
 // Each of the 16 domains can be either allowed full access (manager)
 // to a region of memory or restricted access to some pages in that region (client).
 bitflags!(flags DomainTypeMask: uint {
-    static KERNEL = 0b11 << 0,
-    static USER   = 0b11 << 2,
-    static NOACCESS = 0,
-    static CLIENT   = 0b01 * 0x55555555,
-    static MANAGER  = 0b11 * 0x55555555
+    const KERNEL = 0b11 << 0,
+    const USER   = 0b11 << 2,
+    const NOACCESS = 0,
+    const CLIENT   = 0b01 * 0x55555555,
+    const MANAGER  = 0b11 * 0x55555555
 })
 
 impl CR {

--- a/arch/x86/cpu/gdt.rs
+++ b/arch/x86/cpu/gdt.rs
@@ -8,28 +8,28 @@ use cpu::DtReg;
 use kernel::heap;
 
 bitflags!(flags GdtAccess: u8 {
-    static ACCESSED = 1 << 0,
-    static EXTEND   = 1 << 1,
-    static CONFORM  = 1 << 2,
-    static CODE     = 1 << 3,
-    static STORAGE  = 1 << 4, // not TSS
+    const ACCESSED = 1 << 0,
+    const EXTEND   = 1 << 1,
+    const CONFORM  = 1 << 2,
+    const CODE     = 1 << 3,
+    const STORAGE  = 1 << 4, // not TSS
 
-    static DPL0 = 0 << 5,
-    static DPL1 = 1 << 5,
-    static DPL2 = 2 << 5,
-    static DPL3 = 3 << 5,
+    const DPL0 = 0 << 5,
+    const DPL1 = 1 << 5,
+    const DPL2 = 2 << 5,
+    const DPL3 = 3 << 5,
 
-    static PRESENT  = 1 << 7,
+    const PRESENT  = 1 << 7,
 
-    static DATA_WRITE = EXTEND.bits,
-    static CODE_READ  = CODE.bits
+    const DATA_WRITE = EXTEND.bits,
+    const CODE_READ  = CODE.bits
                       | EXTEND.bits,
-    static TSS        = 0b1001
+    const TSS        = 0b1001
 })
 
 bitflags!(flags GdtFlags: u8 {
-    static SIZE_32  = 1 << 6,
-    static PAGES    = 1 << 7
+    const SIZE_32  = 1 << 6,
+    const PAGES    = 1 << 7
 })
 
 pub type GdtReg = DtReg<GdtEntry>;

--- a/arch/x86/cpu/idt.rs
+++ b/arch/x86/cpu/idt.rs
@@ -5,9 +5,9 @@ use core;
 use super::DtReg;
 
 bitflags!(flags IdtFlags: u8 {
-    static INTR_GATE = 0b1110,
-    static TRAP_GATE = 0b1111,
-    static PRESENT = 1 << 7
+    const INTR_GATE = 0b1110,
+    const TRAP_GATE = 0b1111,
+    const PRESENT = 1 << 7
 })
 
 pub type IdtReg = DtReg<IdtEntry>;

--- a/arch/x86/cpu/mmu.rs
+++ b/arch/x86/cpu/mmu.rs
@@ -16,21 +16,21 @@ use kernel;
 pub type Frame = [u8, ..PAGE_SIZE];
 
 bitflags!(flags Flags: uint {
-    static PRESENT  = 1 << 0,
-    static RW       = 1 << 1,
-    static USER     = 1 << 2,
-    static ACCESSED = 1 << 5,
-    static HUGE     = 1 << 7
+    const PRESENT  = 1 << 0,
+    const RW       = 1 << 1,
+    const USER     = 1 << 2,
+    const ACCESSED = 1 << 5,
+    const HUGE     = 1 << 7
 })
 
 #[repr(packed)]
 pub struct Page(uint);
 
-static PAGE_SIZE: uint = 0x1000;
-static PAGE_SIZE_LOG2: uint = 12;
-static ENTRIES:   uint = 1024;
+const PAGE_SIZE: uint = 0x1000;
+const PAGE_SIZE_LOG2: uint = 12;
+const ENTRIES:   uint = 1024;
 
-static DIR_VADDR: uint = 0xFFFFF000;
+const DIR_VADDR: uint = 0xFFFFF000;
 
 struct VMemLayout {
     temp1: PageDirectory,                    // @ 0xFF7FF000

--- a/arch/x86/cpu/mod.rs
+++ b/arch/x86/cpu/mod.rs
@@ -33,8 +33,8 @@ macro_rules! cpuid(
 )
 
 bitflags!(flags Eflags: u32 {
-    static CF = 1 << 0,
-    static IF = 1 << 9
+    const CF = 1 << 0,
+    const IF = 1 << 9
 })
 
 impl Eflags {
@@ -49,7 +49,7 @@ impl Eflags {
 
 bitflags!(flags CR0Flags: u32 {
     // TODO: all flags
-    static CR0_PG = 1 << 31
+    const CR0_PG = 1 << 31
 })
 
 struct CR0;

--- a/arch/x86/drivers/vga.rs
+++ b/arch/x86/drivers/vga.rs
@@ -36,7 +36,7 @@ impl Char {
     }
 }
 
-pub static SCREEN_SIZE: uint = 80*25;
+pub const SCREEN_SIZE: uint = 80*25;
 type Screen = [Char, ..SCREEN_SIZE];
 pub static SCREEN: *mut Screen = 0xb8000 as *mut Screen;
 

--- a/common/kernel/elf/mod.rs
+++ b/common/kernel/elf/mod.rs
@@ -32,9 +32,9 @@ enum HeaderType {
 }
 
 bitflags!(flags HeaderFlags: u32 {
-    static PT_X = 1,
-    static PT_R = 2,
-    static PT_W = 4
+    const PT_X = 1,
+    const PT_R = 2,
+    const PT_W = 4
 })
 
 #[repr(packed)]
@@ -130,13 +130,13 @@ impl PhdrT for self::Phdr {
 impl ELFIdent {
     unsafe fn load(&self) -> Option<&Ehdr> {
         // TODO: check endianness
-        static MAGIC_STRING : &'static str = "\u007fELF";
+        const MAGIC_STRING : &'static str = "\u007fELF";
         if *(MAGIC_STRING.as_ptr() as *const u32) != transmute(self.ei_mag) {
             return None;
         }
 
-        #[cfg(target_word_size = "32")] static CLASS: u8 = 1;
-        #[cfg(target_word_size = "64")] static CLASS: u8 = 2;
+        #[cfg(target_word_size = "32")] const CLASS: u8 = 1;
+        #[cfg(target_word_size = "64")] const CLASS: u8 = 2;
 
         match self.ei_class {
             CLASS => return Some(transmute(self)),

--- a/common/macros.rs
+++ b/common/macros.rs
@@ -6,7 +6,7 @@ macro_rules! define_reg (
             $($flag:ident $(= $v:expr)*),*
         }
     ) => (
-        bitflags!(flags $flags: $T { $( static $flag $(= $v)* ),* })
+        bitflags!(flags $flags: $T { $( const $flag $(= $v)* ),* })
 
         pub struct $Reg;
 

--- a/common/rust_core/bitflags.rs
+++ b/common/rust_core/bitflags.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! A typesafe bitmask flag generator.
+
 //! The `bitflags!` macro generates a `struct` that holds a set of C-style
 //! bitmask flags. It is useful for creating typesafe wrappers for C APIs.
 //!
@@ -16,42 +18,39 @@
 //!
 //! # Example
 //!
-//! ~~~rust
-//! bitflags!(
+//! ```{.rust}
+//! bitflags! {
 //!     flags Flags: u32 {
-//!         static FlagA       = 0x00000001,
-//!         static FlagB       = 0x00000010,
-//!         static FlagC       = 0x00000100,
-//!         static FlagAB      = FlagA.bits
-//!                            | FlagB.bits,
-//!         static FlagABC     = FlagA.bits
-//!                            | FlagB.bits
-//!                            | FlagC.bits
+//!         const FLAG_A       = 0x00000001,
+//!         const FLAG_B       = 0x00000010,
+//!         const FLAG_C       = 0x00000100,
+//!         const FLAG_ABC     = FLAG_A.bits
+//!                            | FLAG_B.bits
+//!                            | FLAG_C.bits,
 //!     }
-//! )
+//! }
 //!
 //! fn main() {
-//!     let e1 = FlagA | FlagC;
-//!     let e2 = FlagB | FlagC;
-//!     assert!((e1 | e2) == FlagABC);   // union
-//!     assert!((e1 & e2) == FlagC);     // intersection
-//!     assert!((e1 ^ e2) == FlagAB);    // symmetric difference
-//!     assert!((e1 - e2) == FlagA);     // set difference
-//!     assert!(!e2 == FlagA);           // set complement
+//!     let e1 = FLAG_A | FLAG_C;
+//!     let e2 = FLAG_B | FLAG_C;
+//!     assert!((e1 | e2) == FLAG_ABC);   // union
+//!     assert!((e1 & e2) == FLAG_C);     // intersection
+//!     assert!((e1 - e2) == FLAG_A);     // set difference
+//!     assert!(!e2 == FLAG_A);           // set complement
 //! }
-//! ~~~
+//! ```
 //!
 //! The generated `struct`s can also be extended with type and trait implementations:
 //!
-//! ~~~rust
+//! ```{.rust}
 //! use std::fmt;
 //!
-//! bitflags!(
+//! bitflags! {
 //!     flags Flags: u32 {
-//!         static FlagA   = 0x00000001,
-//!         static FlagB   = 0x00000010
+//!         const FLAG_A   = 0x00000001,
+//!         const FLAG_B   = 0x00000010,
 //!     }
-//! )
+//! }
 //!
 //! impl Flags {
 //!     pub fn clear(&mut self) {
@@ -67,12 +66,12 @@
 //! }
 //!
 //! fn main() {
-//!     let mut flags = FlagA | FlagB;
+//!     let mut flags = FLAG_A | FLAG_B;
 //!     flags.clear();
 //!     assert!(flags.is_empty());
 //!     assert_eq!(format!("{}", flags).as_slice(), "hi!");
 //! }
-//! ~~~
+//! ```
 //!
 //! # Attributes
 //!
@@ -91,7 +90,7 @@
 //!
 //! - `BitOr`: union
 //! - `BitAnd`: intersection
-//! - `BitXor`: symmetric difference
+//! - `BitXor`: toggle
 //! - `Sub`: set difference
 //! - `Not`: set complement
 //!
@@ -108,22 +107,23 @@
 //! - `contains`: `true` all of the flags in `other` are contained within `self`
 //! - `insert`: inserts the specified flags in-place
 //! - `remove`: removes the specified flags in-place
-
+//! - `toggle`: the specified flags will be inserted if not present, and removed
+//!             if they are.
 #![experimental]
 #![macro_escape]
 
 #[macro_export]
-macro_rules! bitflags(
+macro_rules! bitflags {
     ($(#[$attr:meta])* flags $BitFlags:ident: $T:ty {
-        $($(#[$Flag_attr:meta])* static $Flag:ident = $value:expr),+
-    }) => (
-        #[deriving(PartialEq, Eq, Clone)]
+        $($(#[$Flag_attr:meta])* const $Flag:ident = $value:expr),+
+    }) => {
+        #[deriving(PartialEq, Eq, Clone, PartialOrd, Ord)]
         $(#[$attr])*
         pub struct $BitFlags {
             bits: $T,
         }
 
-        $($(#[$Flag_attr])* pub static $Flag: $BitFlags = $BitFlags { bits: $value };)+
+        $($(#[$Flag_attr])* pub const $Flag: $BitFlags = $BitFlags { bits: $value };)+
 
         impl $BitFlags {
             /// Returns an empty set of flags.
@@ -173,6 +173,7 @@ macro_rules! bitflags(
             }
 
             /// Returns `true` all of the flags in `other` are contained within `self`.
+            #[inline]
             pub fn contains(&self, other: $BitFlags) -> bool {
                 (self & other) == other
             }
@@ -186,6 +187,11 @@ macro_rules! bitflags(
             pub fn remove(&mut self, other: $BitFlags) {
                 self.bits &= !other.bits;
             }
+
+            /// Toggles the specified flags in-place.
+            pub fn toggle(&mut self, other: $BitFlags) {
+                self.bits ^= other.bits;
+            }
         }
 
         impl core::ops::BitOr<$BitFlags, $BitFlags> for $BitFlags {
@@ -196,19 +202,19 @@ macro_rules! bitflags(
             }
         }
 
+        impl core::ops::BitXor<$BitFlags, $BitFlags> for $BitFlags {
+            /// Returns the left flags, but with all the right flags toggled.
+            #[inline]
+            fn bitxor(&self, other: &$BitFlags) -> $BitFlags {
+                $BitFlags { bits: self.bits ^ other.bits }
+            }
+        }
+
         impl core::ops::BitAnd<$BitFlags, $BitFlags> for $BitFlags {
             /// Returns the intersection between the two sets of flags.
             #[inline]
             fn bitand(&self, other: &$BitFlags) -> $BitFlags {
                 $BitFlags { bits: self.bits & other.bits }
-            }
-        }
-
-        impl core::ops::BitXor<$BitFlags, $BitFlags> for $BitFlags {
-            /// Returns the symmetric difference between the two sets of flags.
-            #[inline]
-            fn bitxor(&self, other: &$BitFlags) -> $BitFlags {
-                $BitFlags { bits: self.bits ^ other.bits }
             }
         }
 
@@ -227,5 +233,15 @@ macro_rules! bitflags(
                 $BitFlags { bits: !self.bits } & $BitFlags::all()
             }
         }
-    )
-)
+    };
+    ($(#[$attr:meta])* flags $BitFlags:ident: $T:ty {
+        $($(#[$Flag_attr:meta])* const $Flag:ident = $value:expr),+,
+    }) => {
+        bitflags! {
+            $(#[$attr])*
+            flags $BitFlags: $T {
+                $($(#[$Flag_attr])* const $Flag = $value),+
+            }
+        }
+    };
+}


### PR DESCRIPTION
Update to reflect the recent renaming of a large category of `static` variables to `const`. This requires copying the latest version of `bitflags.rs` from Rust's libstd.
