### PR TITLE
Fixes to align with rust 1.2

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -10,7 +10,7 @@ MAYBE_DEBUG    ?= -g
 endif
 
 ifndef DEBUG
-MAYBE_RUSTC_OPTIMIZE ?= --opt-level=2 -C lto
+MAYBE_RUSTC_OPTIMIZE ?= -C opt-level=2 -C lto
 MAYBE_CLANG_OPTIMIZE ?= -O2
 endif
 
@@ -36,7 +36,7 @@ DEP_SCRIPT     ?= 's~\($(DEP_KEEP)\)~\n\1~g;s~ \S*$(DEP_RM)\S*~~g;s~\n\($(DEP_KE
 
 # Compile rustboot. Produce dependency info
 $(BDIR)/main.bc: ../../common/lib.rs
-	$(RUSTC) $(RUSTCFLAGS) -L $(BDIR) --out-dir $(BDIR) --dep-info --emit=bc $<
+	$(RUSTC) $(RUSTCFLAGS) -L $(BDIR) --out-dir $(BDIR) --emit=dep-info,llvm-bc $<
 	@sed -e $(DEP_SCRIPT) $(BDIR)/main.d > $(BDIR)/main.d.tmp
 	@mv $(BDIR)/main.d.tmp $(BDIR)/main.d		# SED to tmp file for OS X compatibility
 


### PR DESCRIPTION
The code in `master` is uncompilable with recent Rust versions, like 1.2. The compiler flags aren't even valid any more. This PR attempts to fix this; the code (`common/macros.rs`) still fail very badly but without this PR you won't even get as far as to see the compilation errors. :smile: 
